### PR TITLE
Events: Add events for record pause and resume

### DIFF
--- a/src/eventhandler/EventHandler.cpp
+++ b/src/eventhandler/EventHandler.cpp
@@ -132,7 +132,7 @@ void EventHandler::ConnectSourceSignals(obs_source_t *source) // Applies to inpu
 		signal_handler_connect(sh, "item_transform", HandleSceneItemTransformChanged, this);
 	}
 }
-	
+
 void EventHandler::DisconnectSourceSignals(obs_source_t *source)
 {
 	if (!source)
@@ -299,6 +299,12 @@ void EventHandler::OnFrontendEvent(enum obs_frontend_event event, void *private_
 			break;
 		case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
 			eventHandler->HandleRecordStateChanged(OBS_WEBSOCKET_OUTPUT_STOPPED);
+			break;
+		case OBS_FRONTEND_EVENT_RECORDING_PAUSED:
+			eventHandler->HandleRecordStateChanged(OBS_WEBSOCKET_OUTPUT_PAUSED);
+			break;
+		case OBS_FRONTEND_EVENT_RECORDING_UNPAUSED:
+			eventHandler->HandleRecordStateChanged(OBS_WEBSOCKET_OUTPUT_RESUMED);
 			break;
 		case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING:
 			eventHandler->HandleReplayBufferStateChanged(OBS_WEBSOCKET_OUTPUT_STARTING);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obs-websocket/obs-websocket/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Add missing events for when recording is paused or resumed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The events were already available in libobs and prepared in obs-websocket, just not connected.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): MacOS

Tested with my `obws` client library and confirmed that the events are fired.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New request/event (non-breaking)
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [**contributing** document](https://github.com/obs-websocket/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-  [ ] My code is not on the master branch.
-  [x] The code has been tested.
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] I have included updates to all appropriate documentation.

